### PR TITLE
Add Vite 4.x Compatibility to vite-plugin-inferno

### DIFF
--- a/packages/vite-plugin-inferno/package.json
+++ b/packages/vite-plugin-inferno/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@babel/core": "7.x",
     "@babel/parser": "7.x",
-    "vite": "2.x || 3.x"
+    "vite": "2.x || 3.x || 4.x"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.14",


### PR DESCRIPTION
Hello,

I have created a pull request to extend compatibility by adding Vite 4.x support to the `vite-plugin-inferno` package. This is achieved by updating the `peerDependencies` field in the package.json file.

This change ensures compatibility with the latest Vite ecosystem, making the package accessible to a broader audience.

I would greatly appreciate it if you could review and merge this pull request if it meets your approval. Please let me know if you have any feedback or suggestions.

Thank you for your time and consideration.

Best regards,
Sofiane-77
